### PR TITLE
Fix: Ensure groups list is always an array

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -71,12 +71,19 @@ async function loadTokens() {
 async function loadGroups() {
   try {
     const result = await chrome.storage.local.get(['repositoryGroups']);
-    if (result.repositoryGroups) {
+    // Ensure that groups.value is always an array
+    if (Array.isArray(result.repositoryGroups)) {
       groups.value = result.repositoryGroups;
+    } else {
+      // If it's not an array (e.g., undefined, null, or corrupted), initialize as an empty array
+      groups.value = [];
+      if (result.repositoryGroups !== undefined) { // Log if there was something but it wasn't an array
+        console.warn('Loaded "repositoryGroups" from storage, but it was not an array. Initializing to empty array. Value was:', result.repositoryGroups);
+      }
     }
   } catch (e) {
     console.error('Error loading groups from storage:', e);
-    // Optionally set an error state for groups
+    groups.value = []; // Also ensure groups is an array in case of an error during storage access
   }
 }
 


### PR DESCRIPTION
The `groups.value` in the store could previously be assigned a non-array value (e.g., null) if `repositoryGroups` loaded from chrome.storage.local was not an array. This would cause a JavaScript error ("push is not a function") when attempting to add a new group.

This commit modifies the `loadGroups` function in `src/store/index.ts` to ensure that `groups.value` is always initialized as an array. If the loaded `repositoryGroups` is not an array, `groups.value` defaults to an empty array `[]`, and a warning is logged to the console if the loaded value was defined but not an array. It also ensures `groups.value` is an empty array if an error occurs during storage access.