### PR TITLE
Fix: Ensure groups are displayed even without repositories

### DIFF
--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -41,7 +41,7 @@
     </div>
 
     <!-- Display Repositories by Group -->
-    <div v-if="!store.isLoading.value && !store.error.value && store.repositories.value.length > 0">
+    <div v-if="!store.isLoading.value && !store.error.value && (store.groups.value.length > 0 || store.repositories.value.length > 0)">
       <!-- Grouped Repositories -->
       <div v-for="(groupRepos, groupName) in store.repositoriesByGroup.value.grouped" :key="groupName" class="mb-3">
         <v-row align="center" no-gutters class="group-header-custom">
@@ -89,7 +89,7 @@
       </div>
     </div>
 
-    <v-row v-if="!store.isLoading.value && !store.error.value && store.repositories.value.length === 0 && store.isAuthenticated.value" justify="center" class="mt-4">
+    <v-row v-if="!store.isLoading.value && !store.error.value && store.repositories.value.length === 0 && store.groups.value.length === 0 && store.isAuthenticated.value" justify="center" class="mt-4">
       <v-col class="text-center">
         <p>No repositories found. Try refreshing.</p>
       </v-col>


### PR DESCRIPTION
Previously, the UI would not show any group information if the list of repositories was empty. This meant newly added groups were not visible if no repositories were loaded, and existing groups would disappear if repositories were cleared.

This commit adjusts the visibility conditions in Popup.vue:
- The main group display area now renders if there are any groups OR any repositories (and not loading/error).
- The "No repositories found" message is refined to only appear if both the repository list and the groups list are empty.

This ensures that groups are always visible and manageable, irrespective of the repository loading state, and newly added groups appear immediately.