### PR TITLE
Refactor: Make home page responsive

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -202,9 +202,8 @@ onMounted(async () => {
 
 <style scoped>
 .popup-container {
-  width: 400px;
-  min-height: 300px;
-  max-height: 500px; /* Max height before scroll */
+  width: 100%;
+  height: 100%;
   overflow-y: auto;
 }
 .repo-link-custom {


### PR DESCRIPTION
The HomeView.vue component was updated to ensure the main container uses the full available screen width and height.

Previously, the `.popup-container` class had fixed width and max-height values, which prevented the layout from adapting to different screen sizes.

These changes were made:
- Removed `width: 400px` from `.popup-container`.
- Removed `min-height: 300px` and `max-height: 500px` from `.popup-container`.
- Added `width: 100%` and `height: 100%` to `.popup-container` to make it fill the screen.
- Kept `overflow-y: auto` to allow scrolling for content that exceeds viewport height.

You have verified that the home page is now responsive.