### PR TITLE
Fix: Correct drag and drop for ungrouped repositories

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -146,7 +146,7 @@ const handleCreateGroup = async () => {
 const onDrop = async (groupId: string | undefined, event: DragEvent) => {
   if (event.dataTransfer) {
     const repoId = event.dataTransfer.getData('text/plain');
-    if (groupId && repoId && repoId !== draggedRepoId.value) { // Ensure it's not a drop on its original (non-group) or same item
+    if (groupId && repoId) { // Ensure it's not a drop on its original (non-group) or same item
       console.log(`Attempting to drop repo ${repoId} into group ${groupId}`);
       try {
         // Check if repo is already in the target group (optional, store might handle this)


### PR DESCRIPTION
The drag and drop functionality was not working when moving an ungrouped repository to a group. This was due to an incorrect condition in the `onDrop` event handler in `HomeView.vue`.

The condition `if (groupId && repoId && repoId !== draggedRepoId.value)` prevented the execution of the group assignment logic. `draggedRepoId.value` is set to the ID of the repository being dragged, and `repoId` is the ID retrieved from the drop event's data transfer. For a legitimate drag operation from the ungrouped list, these IDs would be the same, causing the condition to fail.

This commit changes the condition to `if (groupId && repoId)`, allowing the repository to be correctly added to the target group. The `draggedRepoId` is still used to prevent other potential misfires and is cleared appropriately after the operation.