### PR TITLE
Refactor: Ensure repository ID is always a string

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,6 +1,6 @@
 // src/services/apiService.ts
 export interface Repository {
-  id: string | number;
+  id: string;
   name: string;
   url: string;
   description?: string;

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -23,7 +23,7 @@ export class GithubService implements ApiService {
       const data = await response.json();
 
       return data.map((repo: any) => ({
-        id: repo.id,
+        id: String(repo.id),
         name: repo.name,
         url: repo.html_url,
         description: repo.description,


### PR DESCRIPTION
I've updated the Repository interface to enforce that 'id' is always a string. I also modified GithubService to convert numeric IDs received from the API to strings. The placeholder data in BitbucketService and GitlabService already used string IDs, so no changes were needed there.

This change ensures consistent typing for repository IDs across your application.