### PR TITLE
Refactor: Improve repository group management buttons

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -209,6 +209,15 @@ loadGroups(); // Load groups when store initializes
 // It's common to export refs directly or wrapped in a function/object.
 // Using readonly for state that shouldn't be mutated directly from components.
 export function useStore() {
+  function getRepoGroupId(repoId: string | number): string | null {
+    for (const group of groups.value) {
+      if (group.repoIds.includes(repoId)) {
+        return group.id;
+      }
+    }
+    return null;
+  }
+
   return {
     // State
     githubToken: readonly(githubToken),
@@ -230,6 +239,7 @@ export function useStore() {
     deleteGroup,
     addRepoToGroup,
     removeRepoFromGroup,
+    getRepoGroupId, // Add this line
     // loadGroups, // No need to expose if auto-loaded
     // saveGroups, // Internal use mostly
   };


### PR DESCRIPTION
This commit refactors the buttons for adding and removing repositories from groups in the HomeView.

Key changes:

- Replaced the generic "+/-" button with context-specific buttons:
  - Ungrouped repositories now display an "Add to" button. Clicking this opens a dialog allowing you to select an existing group.
  - Grouped repositories now display an "x" (remove) icon button, which removes the repository from its current group.
- Implemented a Vuetify dialog (`v-dialog`) for the "Add to" functionality, providing a user-friendly way to select a target group.
- Removed the old `assignToGroupPrompt` method that used a browser prompt.
- Added a helper function `getRepoGroupId` to the store (`useStore`) to centralize the logic for finding a repository's current group ID.
- Updated `HomeView.vue` to use the new buttons, dialog, and store helper.

These changes enhance your experience for managing repository groups by providing clearer actions and a more intuitive interface.