### PR TITLE
feat: Implement repository list caching

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -231,7 +231,7 @@ const hasAnyDisplayableRepos = computed(() => {
 const openOptionsPage = () => {
   router.push('/options');
 };
-const refreshRepos = () => store.fetchRepositories();
+const refreshRepos = () => store.fetchRepositories({ forceRefresh: true });
 
 const handleCreateGroup = async () => {
   if (!newGroupName.value.trim()) return;
@@ -372,12 +372,12 @@ const removeRepoFromGroup = async (repo: Repository) => {
 };
 
 onMounted(async () => {
-  // Store now auto-loads tokens and groups.
-  // Fetch repositories if authenticated.
+  // Store now auto-loads tokens, groups, and attempts to load repos from cache.
+  // Call fetchRepositories to ensure data is fresh or fetched if cache is stale/empty.
+  // forceRefresh: false allows fetchRepositories to use its internal logic
+  // to determine if a network request is actually needed.
   if (store.isAuthenticated.value) {
-    if (store.repositories.value.length === 0) { // Fetch only if not already populated
-        await store.fetchRepositories();
-    }
+    await store.fetchRepositories({ forceRefresh: false });
   }
 });
 


### PR DESCRIPTION
Implements caching for the repository list to improve performance on subsequent views and reduce API calls.

Key changes:
- Repositories fetched from the API are now stored in localStorage with a timestamp.
- On store initialization, repositories are loaded from this cache if the data is present and not expired (1-hour expiry).
- The `fetchRepositories` action in the store now accepts a `forceRefresh` option. If true, it bypasses the cache.
- A periodic background refresh (every 30 minutes) is initiated if you are authenticated, calling `fetchRepositories` (without forcing refresh) to update the cache if it's stale.
- The manual refresh button in HomeView now forces a cache bypass.
- The initial load in HomeView is now cache-aware, only fetching from the network if no valid cache is present or if the cache is stale.